### PR TITLE
Bug: Static to dynamic directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.4
+
+- Fixed bug with Parser directoryName property not being respected
+
 ## 3.0.3
 
 - Small fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.4
 
 - Fixed bug with Parser directoryName property not being respected
+- Removed unused purgePasses method
 
 ## 3.0.3
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -145,7 +145,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.3"
+    version: "3.0.4"
   glob:
     dependency: transitive
     description:

--- a/lib/core/passkit.dart
+++ b/lib/core/passkit.dart
@@ -16,11 +16,6 @@ class Passkit {
 
   Passkit({this.directoryName = 'passes'});
 
-  Future<void> purgePasses() async {
-    final root = await fs.createDirectory(name: directoryName);
-    root.deleteSync(recursive: true);
-  }
-
   Future<PasskitGenerated> generate({
     required final String id,
     required final Directory directory,
@@ -37,7 +32,7 @@ class Passkit {
     bool override = false,
   }) async {
     final fs = Fs();
-    final directory = await fs.createDirectory(name: 'passes');
+    final directory = await fs.createDirectory(name: directoryName);
     final childDirectory = Directory('${directory.path}/$id');
     final creators = Creators(directory: childDirectory);
 

--- a/lib/flutter_wallet_card.dart
+++ b/lib/flutter_wallet_card.dart
@@ -91,8 +91,4 @@ class FlutterWalletCard {
 
     return (result != null && result);
   }
-
-  static Future<void> purgePasses() async {
-    await Passkit().purgePasses();
-  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_wallet_card
 description: Flutter wallet card for iOS devices. Generate Apple Pass card using either locally stored file or download it from web via url.
-version: 3.0.3
+version: 3.0.4
 homepage: https://github.com/WebEferen/flutter_wallet_card
 repository: https://github.com/WebEferen/flutter_wallet_card.git
 issue_tracker: https://github.com/WebEferen/flutter_wallet_card/issues

--- a/test/passkit_test.dart
+++ b/test/passkit_test.dart
@@ -70,7 +70,7 @@ void main() {
         });
 
         final passesDirectory = Directory('passes');
-        final passkit = Passkit(directoryName: outputDirectory.path);
+        final passkit = Passkit(directoryName: passesDirectory.path);
         final pass = File('${exampleDirectory.path}/pass.json');
         final pkpass = File('${passesDirectory.path}/testowo.pkpass');
 


### PR DESCRIPTION
- Fixed `Parser()` `directoryName` not being respected.
- Removed unused `purgePasses` method.