### PR TITLE
Support archive 4.0

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.7"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -137,7 +137,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.0.4"
   http_parser:
     dependency: transitive
     description:
@@ -158,10 +158,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -274,6 +274,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.3"
   process:
     dependency: transitive
     description:
@@ -371,10 +379,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:

--- a/lib/core/card_generator.dart
+++ b/lib/core/card_generator.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:crypto/crypto.dart';
+
 import 'package:archive/archive_io.dart';
+import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as path;
+
 import '../models/wallet_card.dart';
-import 'wallet_platform.dart';
 import 'file_manager.dart';
+import 'wallet_platform.dart';
 
 /// Abstract base class for card generators
 abstract class CardGenerator {
@@ -284,7 +286,7 @@ class AppleWalletGenerator extends CardGenerator {
   Future<void> _createPkpassArchive(
       Directory sourceDir, File outputFile) async {
     final encoder = ZipFileEncoder();
-    encoder.zipDirectory(sourceDir, filename: outputFile.path);
+    return encoder.zipDirectory(sourceDir, filename: outputFile.path);
   }
 }
 

--- a/lib/core/file_manager.dart
+++ b/lib/core/file_manager.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
 import 'dart:math';
+
+import 'package:archive/archive_io.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
-import 'package:archive/archive_io.dart';
+
 import 'wallet_platform.dart';
 
 /// File management utility for wallet card operations
@@ -111,7 +113,7 @@ class FileManager {
 
     try {
       final encoder = ZipFileEncoder();
-      encoder.zipDirectory(sourceDir, filename: outputFile.path);
+      await encoder.zipDirectory(sourceDir, filename: outputFile.path);
       return outputFile;
     } catch (e) {
       throw WalletException('Failed to create archive: $e');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: "direct main"
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.7"
   args:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.3"
   cli_config:
     dependency: transitive
     description:
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -234,7 +234,7 @@ packages:
     source: hosted
     version: "2.1.3"
   file:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
@@ -351,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -523,6 +523,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.3"
   pub_semver:
     dependency: transitive
     description:
@@ -724,10 +732,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -785,5 +793,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  archive: ^3.4.10
+  archive: ^4.0.0
   crypto: ^3.0.3
   dio: ^5.4.0
   equatable: ^2.0.5
@@ -29,6 +29,7 @@ dev_dependencies:
   json_serializable: ^6.7.1
   mockito: ^5.4.4
   test: ^1.25.15
+  file: ^7.0.1
 
 flutter:
   plugin:

--- a/test/core/card_generator_test.dart
+++ b/test/core/card_generator_test.dart
@@ -1,20 +1,28 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:ui';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_wallet_card/core/card_generator.dart';
 import 'package:flutter_wallet_card/models/wallet_card.dart';
-import 'package:path/path.dart' as path;
+
+import '../utils/memory_io_overrides.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('CardGenerator', () {
-    late Directory tempDir;
     late WalletCard testCard;
 
     setUp(() async {
-      tempDir = await Directory.systemTemp.createTemp('card_generator_test_');
+      IOOverrides.global = MemoryIOOverrides();
+    });
+
+    tearDown(() {
+      IOOverrides.global = null;
+    });
+
+    setUp(() async {
       testCard = const WalletCard(
         id: 'test-card-123',
         type: WalletCardType.generic,
@@ -34,12 +42,6 @@ void main() {
           labelColor: Color(0xFF666666),
         ),
       );
-    });
-
-    tearDown(() async {
-      if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
-      }
     });
 
     group('AppleWalletGenerator', () {
@@ -110,7 +112,7 @@ void main() {
       });
 
       test('should generate file successfully', () async {
-        final outputFile = File(path.join(tempDir.path, 'test.pkpass'));
+        final outputFile = File('test.pkpass');
 
         final result = await generator.generateFile(testCard, outputFile);
 
@@ -230,7 +232,7 @@ void main() {
           },
         );
 
-        final outputFile = File(path.join(tempDir.path, 'test.json'));
+        final outputFile = File('test.json');
 
         final result = await generator.generateFile(validCard, outputFile);
 

--- a/test/flutter_wallet_card_test.dart
+++ b/test/flutter_wallet_card_test.dart
@@ -1,13 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:archive/archive.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_wallet_card/core/wallet_factory.dart';
+import 'package:flutter_wallet_card/core/wallet_platform.dart';
 import 'package:flutter_wallet_card/flutter_wallet_card.dart';
 import 'package:flutter_wallet_card/models/wallet_card.dart';
-import 'package:flutter_wallet_card/core/wallet_platform.dart';
-import 'package:flutter_wallet_card/core/wallet_factory.dart';
-
 import 'package:mockito/annotations.dart';
 import 'package:path/path.dart' as path;
 
@@ -134,7 +134,7 @@ void main() {
         archive.addFile(
             ArchiveFile('pass.json', passJsonBytes.length, passJsonBytes));
         final zipData = ZipEncoder().encode(archive);
-        await pkpassFile.writeAsBytes(zipData!);
+        await pkpassFile.writeAsBytes(zipData);
 
         final card = await FlutterWalletCard.parseFromFile(pkpassFile);
 

--- a/test/utils/memory_io_overrides.dart
+++ b/test/utils/memory_io_overrides.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:file/memory.dart';
+
+class MemoryIOOverrides extends IOOverrides {
+  final MemoryFileSystem fs;
+
+  MemoryIOOverrides({MemoryFileSystem? fs}) : fs = fs ?? MemoryFileSystem();
+
+  @override
+  Directory createDirectory(String path) => fs.directory(path);
+
+  @override
+  File createFile(String path) => fs.file(path);
+
+  @override
+  Directory getSystemTempDirectory() => fs.directory('/tmp')..createSync();
+}


### PR DESCRIPTION
Some packages depend on `archive: ^4.0.0` nowadays which this package conflicts without this change. Sadly both `^3` and `^4` cannot be supported at the same time as the `zipDirectory()` method is sync in 3.0, but async in 4.0. So this must bump at least the minor version.

I refactored the tests to use a memory filesystem instead of creating random files. This is not required for archive 4.0, but it is better to not have side effects like this in tests.

Archive 3.0 could be supported by writing a wrapper class for the used archive methods. I could try to do this if really necessary.